### PR TITLE
Fix payload pointer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,10 @@ INCLUDE_INSTALL=$(HOME)/include
 CURDIR=/opt/local/lib -L.
 TEST_LIBS=-L$(CURDIR) -lcunit
 
-CPPFLAGS=-DDEBUG -I/opt/local/include
+CPPFLAGS=-I/opt/local/include
+#Uncomment this to enabel debug output and symbols
+CPPFLAGS+=-DDEBUG -O0 -g 
+
 CFLAGS=-Wall -std=c99
 CXXFLAGS=-Wall -std=c++11
 

--- a/cantcoap.cpp
+++ b/cantcoap.cpp
@@ -25,20 +25,18 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 // version, 2 bits
 // type, 2 bits
-	// 00 Confirmable
-	// 01 Non-confirmable
-	// 10 Acknowledgement
-	// 11 Reset
+// 00 Confirmable
+// 01 Non-confirmable
+// 10 Acknowledgement
+// 11 Reset
 
 // token length, 4 bits
 // length of token in bytes (only 0 to 8 bytes allowed)
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
-#include <unistd.h>
 #include <string.h>
 #include "cantcoap.h"
-#include "arpa/inet.h"
 #include "sysdep.h"
 
 /// Memory-managed constructor. Buffer for PDU is dynamically sized and allocated by the object.

--- a/cantcoap.cpp
+++ b/cantcoap.cpp
@@ -249,14 +249,8 @@ int CoapPDU::validate() {
 
 	// check that code is valid
 	CoapPDU::Code code = getCode();
-	if(code<COAP_EMPTY ||
-		(code>COAP_LASTMETHOD&&code<COAP_CREATED) ||
-		(code>COAP_CONTENT&&code<COAP_BAD_REQUEST) ||
-		(code>COAP_NOT_ACCEPTABLE&&code<COAP_PRECONDITION_FAILED) ||
-		(code==0x8E) ||
-		(code>COAP_UNSUPPORTED_CONTENT_FORMAT&&code<COAP_INTERNAL_SERVER_ERROR) ||
-		(code>COAP_PROXYING_NOT_SUPPORTED) ) {
-		DBG("Invalid CoAP code: %d",code);
+	if(code < COAP_EMPTY || coapResponseClass(code) > COAP_MAX_RESPONSE_CLASS) {
+		DBG("Invalid CoAP code: %d, class: %d",code,coapResponseClass(code));
 		return 0;
 	}
 	DBG("CoAP code: %d",code);

--- a/cantcoap.cpp
+++ b/cantcoap.cpp
@@ -1356,6 +1356,10 @@ void CoapPDU::shiftPDUUp(int shiftOffset, int shiftAmount) {
 		destPointer--;
 		srcPointer--;
 	}
+	// shift the payload pointer
+	if (_payloadLength > 0) {
+		_payloadPointer += shiftOffset;
+	}
 }
 
 /// Moves a block of bytes down a specified number of steps.
@@ -1373,6 +1377,10 @@ void CoapPDU::shiftPDUDown(int startLocation, int shiftOffset, int shiftAmount) 
 		_pdu[startLocation] = _pdu[srcPointer];
 		startLocation++;
 		srcPointer++;
+	}
+	// shift the payload pointer
+	if (_payloadLength > 0) {
+		_payloadPointer -= shiftOffset;
 	}
 }
 

--- a/cantcoap.cpp
+++ b/cantcoap.cpp
@@ -1259,7 +1259,7 @@ uint8_t* CoapPDU::getPayloadCopy() {
  *
  * \return 0 on success, 1 on failure.
  */
-int CoapPDU::setContentFormat(CoapPDU::ContentFormat format) {
+int CoapPDU::setContentFormat(uint16_t format) {
 	if(format==0) {
 		// minimal representation means null option value
 		if(addOption(CoapPDU::COAP_OPTION_CONTENT_FORMAT,0,NULL)!=0) {

--- a/cantcoap.h
+++ b/cantcoap.h
@@ -26,6 +26,11 @@
 #define COAP_MAX_BLOCK_SZX 6
 #endif /* COAP_MAX_BLOCK_SZX */
 
+#ifndef COAP_MAX_RESPONSE_CLASS
+//The largest value for the response codes class, As of draft-ietf-core-coap-04.
+#define COAP_MAX_RESPONSE_CLASS 5
+#endif /* COAP_MAX_RESPONSE_CLASS */
+
 class CoapPDU {
 
 
@@ -51,6 +56,7 @@ class CoapPDU {
 			COAP_VALID,
 			COAP_CHANGED,
 			COAP_CONTENT,
+			COAP_CONTINUE=0x5F,
 			COAP_BAD_REQUEST=0x80,
 			COAP_UNAUTHORIZED,
 			COAP_BAD_OPTION,
@@ -58,6 +64,7 @@ class CoapPDU {
 			COAP_NOT_FOUND,
 			COAP_METHOD_NOT_ALLOWED,
 			COAP_NOT_ACCEPTABLE,
+			COAP_REQUEST_ENTITY_INCOMPLETE=0x88,
 			COAP_PRECONDITION_FAILED=0x8C,
 			COAP_REQUEST_ENTITY_TOO_LARGE=0x8D,
 			COAP_UNSUPPORTED_CONTENT_FORMAT=0x8F,
@@ -169,6 +176,21 @@ class CoapPDU {
 		void setCode(CoapPDU::Code code);
 		CoapPDU::Code getCode();
 		CoapPDU::Code httpStatusToCode(int httpStatus);
+
+		/* CoAP result codes (HTTP-Code / 100 * 40 + HTTP-Code % 100) */
+
+		/* As of draft-ietf-core-coap-04, response codes are encoded to base
+		* 32, i.e.  the three upper bits determine the response class while
+		* the remaining five fine-grained information specific to that class.
+		*/
+		constexpr unsigned httpStatusToCoapUnsignedCode(unsigned httpStatus) {
+			return (httpStatus / 100 << 5) | httpStatus % 100;
+		}
+
+		/* Determines the class of response code C */
+		constexpr unsigned coapResponseClass(CoapPDU::Code code) {
+			return (code >> 5) & 0xFF;
+		}
 
 		// message ID
 		int setMessageID(uint16_t messageID);

--- a/cantcoap.h
+++ b/cantcoap.h
@@ -91,12 +91,35 @@ class CoapPDU {
 
 		/// CoAP content-formats.
 		enum ContentFormat {
-			COAP_CONTENT_FORMAT_TEXT_PLAIN = 0,
-			COAP_CONTENT_FORMAT_APP_LINK  = 40,
-			COAP_CONTENT_FORMAT_APP_XML,
-			COAP_CONTENT_FORMAT_APP_OCTET,
-			COAP_CONTENT_FORMAT_APP_EXI   = 47,
-			COAP_CONTENT_FORMAT_APP_JSON  = 50
+			/* https://www.iana.org/assignments/core-parameters/core-parameters.xhtml#content-formats */
+			/* 0-255  Expert Review */
+			COAP_CONTENT_FORMAT_TEXT_PLAIN           = 0    ,  //  text/plain; charset=utf-8                    /* Ref: [RFC2046][RFC3676][RFC5147] */
+			COAP_CONTENT_FORMAT_APP_COSE_ENCRYPT0    = 16   ,  //  application/cose; cose-type="cose-encrypt0"  /* Ref: [RFC8152] */
+			COAP_CONTENT_FORMAT_APP_COSE_MAC0        = 17   ,  //  application/cose; cose-type="cose-mac0"      /* Ref: [RFC8152] */
+			COAP_CONTENT_FORMAT_APP_COSE_SIGN1       = 18   ,  //  application/cose; cose-type="cose-sign1"     /* Ref: [RFC8152] */
+			COAP_CONTENT_FORMAT_APP_LINKFORMAT       = 40   ,  //  application/link-format                      /* Ref: [RFC6690] */
+			COAP_CONTENT_FORMAT_APP_XML              = 41   ,  //  application/xml                              /* Ref: [RFC3023] */
+			COAP_CONTENT_FORMAT_APP_OCTECT_STREAM    = 42   ,  //  application/octet-stream                     /* Ref: [RFC2045][RFC2046] */
+			COAP_CONTENT_FORMAT_APP_EXI              = 47   ,  //  application/exi                              /* Ref: ["Efficient XML Interchange (EXI) Format 1.0 (Second Edition)" ,February 2014] */
+			COAP_CONTENT_FORMAT_APP_JSON             = 50   ,  //  application/json                             /* Ref: [RFC4627] */
+			COAP_CONTENT_FORMAT_APP_JSON_PATCH_JSON  = 51   ,  //  application/json-patch+json                  /* Ref: [RFC6902] */
+			COAP_CONTENT_FORMAT_APP_MERGE_PATCH_JSON = 52   ,  //  application/merge-patch+json                 /* Ref: [RFC7396] */
+			COAP_CONTENT_FORMAT_APP_CBOR             = 60   ,  //  application/cbor                             /* Ref: [RFC7049] */
+			COAP_CONTENT_FORMAT_APP_CWT              = 61   ,  //  application/cwt                              /* Ref: [RFC8392] */
+			COAP_CONTENT_FORMAT_APP_COSE_ENCRYPT     = 96   ,  //  application/cose; cose-type="cose-encrypt"   /* Ref: [RFC8152] */
+			COAP_CONTENT_FORMAT_APP_COSE_MAC         = 97   ,  //  application/cose; cose-type="cose-mac"       /* Ref: [RFC8152] */
+			COAP_CONTENT_FORMAT_APP_COSE_SIGN        = 98   ,  //  application/cose; cose-type="cose-sign"      /* Ref: [RFC8152] */
+			COAP_CONTENT_FORMAT_APP_COSE_KEY         = 101  ,  //  application/cose-key                         /* Ref: [RFC8152] */
+			COAP_CONTENT_FORMAT_APP_COSE_KEY_SET     = 102  ,  //  application/cose-key-set                     /* Ref: [RFC8152] */
+			COAP_CONTENT_FORMAT_APP_COAP_GROUP_JSON  = 256  ,  //  application/coap-group+json                  /* Ref: [RFC7390] */
+			/* 256-9999  IETF Review or IESG Approval */
+			COAP_CONTENT_FORMAT_APP_OMA_TLV_OLD      = 1542 ,  //  Keep old value for backward-compatibility    /* Ref: [OMA-TS-LightweightM2M-V1_0] */
+			COAP_CONTENT_FORMAT_APP_OMA_JSON_OLD     = 1543 ,  //  Keep old value for backward-compatibility    /* Ref: [OMA-TS-LightweightM2M-V1_0] */
+			/* 10000-64999  First Come First Served */
+			COAP_CONTENT_FORMAT_APP_VND_OCF_CBOR     = 10000,  //  application/vnd.ocf+cbor                     /* Ref: [Michael_Koster] */
+			COAP_CONTENT_FORMAT_APP_OMA_TLV          = 11542,  //  application/vnd.oma.lwm2m+tlv                /* Ref: [OMA-TS-LightweightM2M-V1_0] */
+			COAP_CONTENT_FORMAT_APP_OMA_JSON         = 11543   //  application/vnd.oma.lwm2m+json               /* Ref: [OMA-TS-LightweightM2M-V1_0] */
+			/* 65000-65535  Experimental use (no operational use) */
 		};
 
 		/// Sequence of these is returned by CoapPDU::getOptions()

--- a/cantcoap.h
+++ b/cantcoap.h
@@ -21,6 +21,11 @@
 // |1 1 1 1 1 1 1 1|    Payload (if any) ...
 // +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 
+#ifndef COAP_MAX_BLOCK_SZX
+//The largest value for the SZX component in a Block option.
+#define COAP_MAX_BLOCK_SZX 6
+#endif /* COAP_MAX_BLOCK_SZX */
+
 class CoapPDU {
 
 
@@ -131,6 +136,13 @@ class CoapPDU {
 			uint8_t *optionValuePointer;
 		};
 
+		/// Structure of Block options. Returned by CoapPDU::getOptionBlock
+		struct CoapBlockOpt	{
+			uint16_t num; /**< block number */
+			uint8_t szx;  /**< block size */
+			bool m;       /**if more blocks follow */
+		};
+
 		// construction and destruction
 		CoapPDU();
 		CoapPDU(uint8_t *pdu, int pduLength);
@@ -175,6 +187,15 @@ class CoapPDU {
 
 		// content format helper
 		int setContentFormat(CoapPDU::ContentFormat format);
+
+		// block options
+		CoapBlockOpt parseOptionBlock(CoapOption* optPtr);
+		CoapBlockOpt getOptionBlock(Option optionType);
+		inline CoapBlockOpt getOptionBlock1() { return getOptionBlock(COAP_OPTION_BLOCK1); }
+		inline CoapBlockOpt getOptionBlock2() { return getOptionBlock(COAP_OPTION_BLOCK2); }
+		bool setOptionBlock(const CoapBlockOpt & blockOpt, Option optionType);
+		inline bool setOptionBlock1(const CoapBlockOpt & blockOpt) { return setOptionBlock(blockOpt, COAP_OPTION_BLOCK1); }
+		inline bool setOptionBlock2(const CoapBlockOpt & blockOpt) { return setOptionBlock(blockOpt, COAP_OPTION_BLOCK2); }
 
 		// payload
 		uint8_t* mallocPayload(int bytes);

--- a/cantcoap.h
+++ b/cantcoap.h
@@ -1,7 +1,6 @@
 #pragma once
 
 /// Copyright (c) 2013, Ashley Mills.
-#include <unistd.h>
 #include <stdint.h>
 #include "dbg.h"
 

--- a/cantcoap.h
+++ b/cantcoap.h
@@ -183,12 +183,12 @@ class CoapPDU {
 		* 32, i.e.  the three upper bits determine the response class while
 		* the remaining five fine-grained information specific to that class.
 		*/
-		constexpr unsigned httpStatusToCoapUnsignedCode(unsigned httpStatus) {
+		static constexpr unsigned httpStatusToCoapUnsignedCode(unsigned httpStatus) {
 			return (httpStatus / 100 << 5) | httpStatus % 100;
 		}
 
 		/* Determines the class of response code C */
-		constexpr unsigned coapResponseClass(CoapPDU::Code code) {
+		static constexpr unsigned coapResponseClass(CoapPDU::Code code) {
 			return (code >> 5) & 0xFF;
 		}
 
@@ -208,7 +208,7 @@ class CoapPDU {
 		int addURIQuery(char *query);
 
 		// content format helper
-		int setContentFormat(CoapPDU::ContentFormat format);
+		int setContentFormat(uint16_t format);
 
 		// block options
 		CoapBlockOpt parseOptionBlock(CoapOption* optPtr);
@@ -279,12 +279,13 @@ class CoapPDU {
 #define COAP_CODE_DELETE 0x04
 
 // Response codes 2.00 - 5.31
-// 2.00 - 2.05
-#define COAP_CODE_CREATED 0x41
-#define COAP_CODE_DELETED 0x42
-#define COAP_CODE_VALID   0x43
-#define COAP_CODE_CHANGED 0x44
-#define COAP_CODE_CONTENT 0x45
+// 2.00 - 2.05 and 2.31
+#define COAP_CODE_CREATED 	0x41
+#define COAP_CODE_DELETED 	0x42
+#define COAP_CODE_VALID   	0x43
+#define COAP_CODE_CHANGED 	0x44
+#define COAP_CODE_CONTENT 	0x45
+#define COAP_CODE_CONTINUE  0x5F
 
 // 4.00 - 4.15
 #define COAP_CODE_BAD_REQUEST                0x80
@@ -294,6 +295,7 @@ class CoapPDU {
 #define COAP_CODE_NOT_FOUND                  0x84
 #define COAP_CODE_METHOD_NOT_ALLOWED         0x85
 #define COAP_CODE_NOT_ACCEPTABLE             0x86
+#define COAP_CODE_REQUEST_ENTITY_INCOMPLETE  0x88
 #define COAP_CODE_PRECONDITION_FAILED        0x8C
 #define COAP_CODE_REQUEST_ENTITY_TOO_LARGE   0x8D
 #define COAP_CODE_UNSUPPORTED_CONTENT_FORMAT 0x8F

--- a/dbg.h
+++ b/dbg.h
@@ -1,9 +1,6 @@
 #pragma once
 #include <stdio.h>
 
-#define DEBUG 1
-//#undef DEBUG
-
 #define DBG_NEWLINE "\n"
 
 #define INFO(...) printf(__VA_ARGS__); printf(DBG_NEWLINE);

--- a/sysdep.h
+++ b/sysdep.h
@@ -22,7 +22,9 @@
 #include <stdint.h>
 
 #ifndef _WIN32
-#include <arpa/inet.h>  /* __BYTE_ORDER */
+#include <arpa/inet.h> /* __BYTE_ORDER */
+#else
+#include <stdlib.h>
 #endif
 
 #if !defined(__LITTLE_ENDIAN__) && !defined(__BIG_ENDIAN__)


### PR DESCRIPTION
Adding the token after the payload would cause the `_payloadPointer` to be off by a few bytes.
The actual content was not be corrupted, but e.g. the output of `printHuman()` was.