### PR TITLE
Update IANA content-format codes

### DIFF
--- a/cantcoap.h
+++ b/cantcoap.h
@@ -93,32 +93,83 @@ class CoapPDU {
 		enum ContentFormat {
 			/* https://www.iana.org/assignments/core-parameters/core-parameters.xhtml#content-formats */
 			/* 0-255  Expert Review */
-			COAP_CONTENT_FORMAT_TEXT_PLAIN           = 0    ,  //  text/plain; charset=utf-8                    /* Ref: [RFC2046][RFC3676][RFC5147] */
-			COAP_CONTENT_FORMAT_APP_COSE_ENCRYPT0    = 16   ,  //  application/cose; cose-type="cose-encrypt0"  /* Ref: [RFC8152] */
-			COAP_CONTENT_FORMAT_APP_COSE_MAC0        = 17   ,  //  application/cose; cose-type="cose-mac0"      /* Ref: [RFC8152] */
-			COAP_CONTENT_FORMAT_APP_COSE_SIGN1       = 18   ,  //  application/cose; cose-type="cose-sign1"     /* Ref: [RFC8152] */
-			COAP_CONTENT_FORMAT_APP_LINKFORMAT       = 40   ,  //  application/link-format                      /* Ref: [RFC6690] */
-			COAP_CONTENT_FORMAT_APP_XML              = 41   ,  //  application/xml                              /* Ref: [RFC3023] */
-			COAP_CONTENT_FORMAT_APP_OCTECT_STREAM    = 42   ,  //  application/octet-stream                     /* Ref: [RFC2045][RFC2046] */
-			COAP_CONTENT_FORMAT_APP_EXI              = 47   ,  //  application/exi                              /* Ref: ["Efficient XML Interchange (EXI) Format 1.0 (Second Edition)" ,February 2014] */
-			COAP_CONTENT_FORMAT_APP_JSON             = 50   ,  //  application/json                             /* Ref: [RFC4627] */
-			COAP_CONTENT_FORMAT_APP_JSON_PATCH_JSON  = 51   ,  //  application/json-patch+json                  /* Ref: [RFC6902] */
-			COAP_CONTENT_FORMAT_APP_MERGE_PATCH_JSON = 52   ,  //  application/merge-patch+json                 /* Ref: [RFC7396] */
-			COAP_CONTENT_FORMAT_APP_CBOR             = 60   ,  //  application/cbor                             /* Ref: [RFC7049] */
-			COAP_CONTENT_FORMAT_APP_CWT              = 61   ,  //  application/cwt                              /* Ref: [RFC8392] */
-			COAP_CONTENT_FORMAT_APP_COSE_ENCRYPT     = 96   ,  //  application/cose; cose-type="cose-encrypt"   /* Ref: [RFC8152] */
-			COAP_CONTENT_FORMAT_APP_COSE_MAC         = 97   ,  //  application/cose; cose-type="cose-mac"       /* Ref: [RFC8152] */
-			COAP_CONTENT_FORMAT_APP_COSE_SIGN        = 98   ,  //  application/cose; cose-type="cose-sign"      /* Ref: [RFC8152] */
-			COAP_CONTENT_FORMAT_APP_COSE_KEY         = 101  ,  //  application/cose-key                         /* Ref: [RFC8152] */
-			COAP_CONTENT_FORMAT_APP_COSE_KEY_SET     = 102  ,  //  application/cose-key-set                     /* Ref: [RFC8152] */
-			COAP_CONTENT_FORMAT_APP_COAP_GROUP_JSON  = 256  ,  //  application/coap-group+json                  /* Ref: [RFC7390] */
+			COAP_CONTENT_FORMAT_TEXT_PLAIN              = 0    ,  //  text/plain; charset=utf-8                    /* Ref: [RFC2046][RFC3676][RFC5147] */
+			COAP_CONTENT_FORMAT_APP_COSE_ENCRYPT0       = 16   ,  //  application/cose; cose-type="cose-encrypt0"  /* Ref: [RFC9052] */
+			COAP_CONTENT_FORMAT_APP_COSE_MAC0           = 17   ,  //  application/cose; cose-type="cose-mac0"      /* Ref: [RFC9052] */
+			COAP_CONTENT_FORMAT_APP_COSE_SIGN1          = 18   ,  //  application/cose; cose-type="cose-sign1"     /* Ref: [RFC9052] */
+			COAP_CONTENT_FORMAT_APP_ACE_CBOR            = 19   ,  //  application/ace+cbor                         /* Ref: [RFC9200] */
+			COAP_CONTENT_FORMAT_IMAGE_GIF               = 21   ,  //  image/gif                                    /* Ref: [W3C] */
+			COAP_CONTENT_FORMAT_IMAGE_JPEG              = 22   ,  //  image/jpeg                                   /* Ref: [ISO/IEC 10918-5] */
+			COAP_CONTENT_FORMAT_IMAGE_PNG               = 23   ,  //  image/png                                    /* Ref: [PNG] */
+			COAP_CONTENT_FORMAT_APP_LINKFORMAT          = 40   ,  //  application/link-format                      /* Ref: [RFC6690] */
+			COAP_CONTENT_FORMAT_APP_XML                 = 41   ,  //  application/xml                              /* Ref: [RFC3023] */
+			COAP_CONTENT_FORMAT_APP_OCTECT_STREAM       = 42   ,  //  application/octet-stream                     /* Ref: [RFC2045][RFC2046] */
+			COAP_CONTENT_FORMAT_APP_EXI                 = 47   ,  //  application/exi                              /* Ref: [EXI Format 1.0 (Second Edition)] */
+			COAP_CONTENT_FORMAT_APP_JSON                = 50   ,  //  application/json                             /* Ref: [RFC8259] */
+			COAP_CONTENT_FORMAT_APP_JSON_PATCH_JSON     = 51   ,  //  application/json-patch+json                  /* Ref: [RFC6902] */
+			COAP_CONTENT_FORMAT_APP_MERGE_PATCH_JSON    = 52   ,  //  application/merge-patch+json                 /* Ref: [RFC7396] */
+			COAP_CONTENT_FORMAT_APP_CBOR                = 60   ,  //  application/cbor                             /* Ref: [RFC8949] */
+			COAP_CONTENT_FORMAT_APP_CWT                 = 61   ,  //  application/cwt                              /* Ref: [RFC8392] */
+			COAP_CONTENT_FORMAT_APP_MULTIPART_CORE      = 62   ,  //  application/multipart-core                   /* Ref: [RFC8710] */
+			COAP_CONTENT_FORMAT_APP_CBOR_SEQ            = 63   ,  //  application/cbor-seq                         /* Ref: [RFC8742] */
+			COAP_CONTENT_FORMAT_APP_EDHOC_CBOR_SEQ      = 64   ,  //  application/edhoc+cbor-seq                   /* Ref: [RFC9528] */
+			COAP_CONTENT_FORMAT_APP_CID_EDHOC_CBOR_SEQ  = 65   ,  //  application/cid-edhoc+cbor-seq               /* Ref: [RFC9528] */
+			COAP_CONTENT_FORMAT_APP_COSE_ENCRYPT        = 96   ,  //  application/cose; cose-type="cose-encrypt"   /* Ref: [RFC9052] */
+			COAP_CONTENT_FORMAT_APP_COSE_MAC            = 97   ,  //  application/cose; cose-type="cose-mac"       /* Ref: [RFC9052] */
+			COAP_CONTENT_FORMAT_APP_COSE_SIGN           = 98   ,  //  application/cose; cose-type="cose-sign"      /* Ref: [RFC9052] */
+			COAP_CONTENT_FORMAT_APP_COSE_KEY            = 101  ,  //  application/cose-key                         /* Ref: [RFC9052] */
+			COAP_CONTENT_FORMAT_APP_COSE_KEY_SET        = 102  ,  //  application/cose-key-set                     /* Ref: [RFC9052] */
+			COAP_CONTENT_FORMAT_APP_SENML_JSON          = 110  ,  //  application/senml+json                       /* Ref: [RFC8428] */
+			COAP_CONTENT_FORMAT_APP_SENSML_JSON         = 111  ,  //  application/sensml+json                      /* Ref: [RFC8428] */
+			COAP_CONTENT_FORMAT_APP_SENML_CBOR          = 112  ,  //  application/senml+cbor                       /* Ref: [RFC8428] */
+			COAP_CONTENT_FORMAT_APP_SENSML_CBOR         = 113  ,  //  application/sensml+cbor                      /* Ref: [RFC8428] */
+			COAP_CONTENT_FORMAT_APP_SENML_EXI           = 114  ,  //  application/senml-exi                        /* Ref: [RFC8428] */
+			COAP_CONTENT_FORMAT_APP_SENSML_EXI          = 115  ,  //  application/sensml-exi                       /* Ref: [RFC8428] */
+			COAP_CONTENT_FORMAT_APP_YANG_DATA_CBOR_SID  = 140  ,  //  application/yang-data+cbor; id=sid           /* Ref: [RFC9254] */
 			/* 256-9999  IETF Review or IESG Approval */
-			COAP_CONTENT_FORMAT_APP_OMA_TLV_OLD      = 1542 ,  //  Keep old value for backward-compatibility    /* Ref: [OMA-TS-LightweightM2M-V1_0] */
-			COAP_CONTENT_FORMAT_APP_OMA_JSON_OLD     = 1543 ,  //  Keep old value for backward-compatibility    /* Ref: [OMA-TS-LightweightM2M-V1_0] */
-			/* 10000-64999  First Come First Served */
-			COAP_CONTENT_FORMAT_APP_VND_OCF_CBOR     = 10000,  //  application/vnd.ocf+cbor                     /* Ref: [Michael_Koster] */
-			COAP_CONTENT_FORMAT_APP_OMA_TLV          = 11542,  //  application/vnd.oma.lwm2m+tlv                /* Ref: [OMA-TS-LightweightM2M-V1_0] */
-			COAP_CONTENT_FORMAT_APP_OMA_JSON         = 11543   //  application/vnd.oma.lwm2m+json               /* Ref: [OMA-TS-LightweightM2M-V1_0] */
+			COAP_CONTENT_FORMAT_APP_COAP_GROUP_JSON     = 256  ,  //  application/coap-group+json                  /* Ref: [RFC7390] */
+			COAP_CONTENT_FORMAT_APP_PROBLEM_CBOR        = 257  ,  //  application/concise-problem-details+cbor     /* Ref: [RFC9290] */
+			COAP_CONTENT_FORMAT_APP_SWID_CBOR           = 258  ,  //  application/swid+cbor                        /* Ref: [RFC9393] */
+			COAP_CONTENT_FORMAT_APP_PKIXCMP             = 259  ,  //  application/pkixcmp                          /* Ref: [RFC9482][RFC9811] */
+			COAP_CONTENT_FORMAT_APP_YANG_SID_JSON       = 260  ,  //  application/yang-sid+json                    /* Ref: [RFC9595] */
+			COAP_CONTENT_FORMAT_APP_ACE_GROUPCOMM_CBOR  = 261  ,  //  application/ace-groupcomm+cbor               /* Ref: [RFC9594] */
+			COAP_CONTENT_FORMAT_APP_ACE_TRL_CBOR        = 262  ,  //  application/ace-trl+cbor                     /* Ref: [RFC9770] */
+			COAP_CONTENT_FORMAT_APP_EAT_CWT             = 263  ,  //  application/eat+cwt                          /* Ref: [RFC9782] */
+			COAP_CONTENT_FORMAT_APP_EAT_JWT             = 264  ,  //  application/eat+jwt                          /* Ref: [RFC9782] */
+			COAP_CONTENT_FORMAT_APP_EAT_BUN_CBOR        = 265  ,  //  application/eat-bun+cbor                     /* Ref: [RFC9782] */
+			COAP_CONTENT_FORMAT_APP_EAT_BUN_JSON        = 266  ,  //  application/eat-bun+json                     /* Ref: [RFC9782] */
+			COAP_CONTENT_FORMAT_APP_EAT_UCS_CBOR        = 267  ,  //  application/eat-ucs+cbor                     /* Ref: [RFC9782] */
+			COAP_CONTENT_FORMAT_APP_EAT_UCS_JSON        = 268  ,  //  application/eat-ucs+json                     /* Ref: [RFC9782] */
+			COAP_CONTENT_FORMAT_APP_COAP_EAP            = 269  ,  //  application/coap-eap                         /* Ref: [RFC9820] */
+			COAP_CONTENT_FORMAT_APP_DOTS_CBOR           = 271  ,  //  application/dots+cbor                        /* Ref: [RFC9132] */
+			COAP_CONTENT_FORMAT_APP_MISSING_BLOCKS_SEQ  = 272  ,  //  application/missing-blocks+cbor-seq          /* Ref: [RFC9177] */
+			COAP_CONTENT_FORMAT_APP_PKCS7_SERVERKEY     = 280  ,  //  application/pkcs7-mime; smime-type=server-generated-key /* Ref: [RFC7030][RFC8551][RFC9148] */
+			COAP_CONTENT_FORMAT_APP_PKCS7_CERTS         = 281  ,  //  application/pkcs7-mime; smime-type=certs-only /* Ref: [RFC8551][RFC9148] */
+			COAP_CONTENT_FORMAT_APP_PKCS8               = 284  ,  //  application/pkcs8                            /* Ref: [RFC5958][RFC8551][RFC9148] */
+			COAP_CONTENT_FORMAT_APP_CSRATTRS            = 285  ,  //  application/csrattrs                         /* Ref: [RFC7030][RFC9148] */
+			COAP_CONTENT_FORMAT_APP_PKCS10              = 286  ,  //  application/pkcs10                           /* Ref: [RFC5967][RFC8551][RFC9148] */
+			COAP_CONTENT_FORMAT_APP_PKIX_CERT           = 287  ,  //  application/pkix-cert                        /* Ref: [RFC2585][RFC9148] */
+			COAP_CONTENT_FORMAT_APP_AIF_CBOR            = 290  ,  //  application/aif+cbor                         /* Ref: [RFC9237] */
+			COAP_CONTENT_FORMAT_APP_AIF_JSON            = 291  ,  //  application/aif+json                         /* Ref: [RFC9237] */
+			COAP_CONTENT_FORMAT_APP_SENML_XML           = 310  ,  //  application/senml+xml                        /* Ref: [RFC8428] */
+			COAP_CONTENT_FORMAT_APP_SENSML_XML          = 311  ,  //  application/sensml+xml                       /* Ref: [RFC8428] */
+			COAP_CONTENT_FORMAT_APP_SENML_ETCH_JSON     = 320  ,  //  application/senml-etch+json                  /* Ref: [RFC8790] */
+			COAP_CONTENT_FORMAT_APP_SENML_ETCH_CBOR     = 322  ,  //  application/senml-etch+cbor                  /* Ref: [RFC8790] */
+			COAP_CONTENT_FORMAT_APP_YANG_DATA_CBOR      = 340  ,  //  application/yang-data+cbor                   /* Ref: [RFC9254] */
+			COAP_CONTENT_FORMAT_APP_YANG_DATA_CBOR_NAME = 341  ,  //  application/yang-data+cbor; id=name          /* Ref: [RFC9254] */
+			COAP_CONTENT_FORMAT_APP_TD_JSON             = 432  ,  //  application/td+json                          /* Ref: [WoT Thing Description 1.1] */
+			COAP_CONTENT_FORMAT_APP_TM_JSON             = 433  ,  //  application/tm+json                          /* Ref: [WoT Thing Description 1.1] */
+			COAP_CONTENT_FORMAT_APP_DNS_MESSAGE         = 553  ,  //  application/dns-message                      /* Ref: [RFC8484] */
+			COAP_CONTENT_FORMAT_APP_UCCS_CBOR           = 601  ,  //  application/uccs+cbor                        /* Ref: [RFC9781, Section 6.4] */
+			COAP_CONTENT_FORMAT_APP_OMA_TLV_OLD         = 1542 ,  //  Keep old value for backward-compatibility    /* Ref: [OMA-TS-LightweightM2M-V1_0] */
+			COAP_CONTENT_FORMAT_APP_OMA_JSON_OLD        = 1543 ,  //  Keep old value for backward-compatibility    /* Ref: [OMA-TS-LightweightM2M-V1_0] */
+			/* 10000-64999  Expert Review / First Come First Served */
+			COAP_CONTENT_FORMAT_APP_VND_OCF_CBOR        = 10000,  //  application/vnd.ocf+cbor                     /* Ref: [Michael_Koster] */
+			COAP_CONTENT_FORMAT_APP_OSCORE              = 10001,  //  application/oscore                           /* Ref: [RFC8613] */
+			COAP_CONTENT_FORMAT_APP_JAVASCRIPT          = 10002,  //  application/javascript                       /* Ref: [RFC4329] */
+			COAP_CONTENT_FORMAT_APP_OMA_TLV             = 11542,  //  application/vnd.oma.lwm2m+tlv                /* Ref: [OMA-TS-LightweightM2M-V1_0] */
+			COAP_CONTENT_FORMAT_APP_OMA_JSON            = 11543,  //  application/vnd.oma.lwm2m+json               /* Ref: [OMA-TS-LightweightM2M-V1_0] */
+			COAP_CONTENT_FORMAT_APP_OMA_CBOR            = 11544   //  application/vnd.oma.lwm2m+cbor               /* Ref: [OMA-TS-LightweightM2M-V1_2] */
 			/* 65000-65535  Experimental use (no operational use) */
 		};
 

--- a/cantcoap.h
+++ b/cantcoap.h
@@ -103,7 +103,7 @@ class CoapPDU {
 			COAP_CONTENT_FORMAT_IMAGE_PNG               = 23   ,  //  image/png                                    /* Ref: [PNG] */
 			COAP_CONTENT_FORMAT_APP_LINKFORMAT          = 40   ,  //  application/link-format                      /* Ref: [RFC6690] */
 			COAP_CONTENT_FORMAT_APP_XML                 = 41   ,  //  application/xml                              /* Ref: [RFC3023] */
-			COAP_CONTENT_FORMAT_APP_OCTECT_STREAM       = 42   ,  //  application/octet-stream                     /* Ref: [RFC2045][RFC2046] */
+			COAP_CONTENT_FORMAT_APP_OCTET_STREAM        = 42   ,  //  application/octet-stream                     /* Ref: [RFC2045][RFC2046] */
 			COAP_CONTENT_FORMAT_APP_EXI                 = 47   ,  //  application/exi                              /* Ref: [EXI Format 1.0 (Second Edition)] */
 			COAP_CONTENT_FORMAT_APP_JSON                = 50   ,  //  application/json                             /* Ref: [RFC8259] */
 			COAP_CONTENT_FORMAT_APP_JSON_PATCH_JSON     = 51   ,  //  application/json-patch+json                  /* Ref: [RFC6902] */


### PR DESCRIPTION
Update `COAP_CONTENT_FORMAT*` to current [IANA version](https://www.iana.org/assignments/core-parameters/core-parameters.xhtml#content-formats). Adds some more identifiers, the existing ones are left untouched (only updated RFC comment where applicable).

Also fix a typo in `COAP_CONTENT_FORMAT_APP_OCTET_STREAM` (breaking change).